### PR TITLE
Fix GitHub Actions permissions for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: write  # Required to create tags and releases
+  packages: read   # Required for caching
+
 jobs:
   check-tag:
     name: Check if release tag exists
@@ -79,6 +83,9 @@ jobs:
       tag: v${{ needs.check-tag.outputs.version }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0
     
     - name: Create and push tag
       run: |
@@ -216,15 +223,14 @@ jobs:
         cat release_notes.txt
     
     - name: Create GitHub Release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: v${{ needs.check-tag.outputs.version }}
-        release_name: Release v${{ needs.check-tag.outputs.version }}
+        name: Release v${{ needs.check-tag.outputs.version }}
         body_path: release_notes.txt
         draft: false
         prerelease: false
+        token: ${{ secrets.GITHUB_TOKEN }}
 
   summary:
     name: Release Summary


### PR DESCRIPTION
- Added permissions: contents: write for tag/release creation
- Added permissions: packages: read for caching
- Updated create-tag job to use GITHUB_TOKEN explicitly
- Updated GitHub release creation to use modern softprops/action-gh-release@v2
- Should resolve 403 permission denied errors for github-actions[bot]